### PR TITLE
feat: session approval with different chain

### DIFF
--- a/src/controllers/engine.ts
+++ b/src/controllers/engine.ts
@@ -61,6 +61,16 @@ export class Engine extends ISingleEthereumEngine {
       },
     };
 
+    const optionalMethods = proposal.optionalNamespaces[EVM_IDENTIFIER]?.methods;
+    if (optionalMethods) {
+      approveParams.namespaces[EVM_IDENTIFIER].methods = approveParams.namespaces[
+        EVM_IDENTIFIER
+      ].methods
+        .concat(optionalMethods)
+        .flat();
+      console.log("optionalMethods", approveParams.namespaces[EVM_IDENTIFIER].methods);
+    }
+
     const session = await this.web3wallet.approveSession(approveParams);
     this.chainId = chainId;
 

--- a/src/controllers/engine.ts
+++ b/src/controllers/engine.ts
@@ -68,7 +68,6 @@ export class Engine extends ISingleEthereumEngine {
       ].methods
         .concat(optionalMethods)
         .flat();
-      console.log("optionalMethods", approveParams.namespaces[EVM_IDENTIFIER].methods);
     }
 
     const session = await this.web3wallet.approveSession(approveParams);

--- a/src/controllers/engine.ts
+++ b/src/controllers/engine.ts
@@ -42,19 +42,40 @@ export class Engine extends ISingleEthereumEngine {
   public approveSession: ISingleEthereumEngine["approveSession"] = async (params) => {
     const { id, chainId, accounts } = params;
     const proposal = this.web3wallet.engine.signClient.proposal.get(id);
+    const requiredChain = proposal.requiredNamespaces[EVM_IDENTIFIER].chains?.[0];
+    const requiredParsed = requiredChain ? parseInt(parseChain(requiredChain)) : chainId;
+    const approvedChains = [requiredParsed];
+
+    if (requiredParsed !== chainId) {
+      approvedChains.push(chainId);
+    }
+
     const approveParams = {
       id,
       namespaces: {
         [EVM_IDENTIFIER]: {
           ...proposal.requiredNamespaces[EVM_IDENTIFIER],
-          accounts: formatAccounts(accounts, chainId),
-          chains: [prefixChainWithNamespace(chainId)],
+          accounts: approvedChains.map((chain) => formatAccounts(accounts, chain)).flat(),
+          chains: approvedChains.map((chain) => prefixChainWithNamespace(chain)),
         },
       },
     };
 
     const session = await this.web3wallet.approveSession(approveParams);
     this.chainId = chainId;
+
+    // emit chainChanged if a different chain is approved other than the required
+    if (approvedChains.length > 1) {
+      await this.web3wallet.emitSessionEvent({
+        topic: session.topic,
+        event: {
+          name: "chainChanged",
+          data: chainId,
+        },
+        chainId: prefixChainWithNamespace(chainId),
+      });
+    }
+
     return session;
   };
 

--- a/test/shared/values.ts
+++ b/test/shared/values.ts
@@ -11,6 +11,7 @@ export const TEST_METHODS = [
   "personal_sign",
   "eth_signTypedData",
 ];
+export const TEST_OPTIONAL_METHODS = ["wallet_addEthereumChain", "wallet_switchEthereumChain"];
 export const TEST_EVENTS = ["chainChanged", "accountsChanged"];
 
 export const TEST_ETHEREUM_ADDRESS = "0x3c582121909DE92Dc89A36898633C1aE4790382b";
@@ -43,6 +44,14 @@ export const TEST_REQUIRED_NAMESPACES = {
     methods: TEST_METHODS,
     chains: [TEST_ETHEREUM_CHAIN],
     events: TEST_EVENTS,
+  },
+};
+
+export const TEST_OPTIONAL_NAMESPACES = {
+  eip155: {
+    methods: TEST_OPTIONAL_METHODS,
+    chains: [TEST_ETHEREUM_CHAIN],
+    events: [],
   },
 };
 

--- a/test/sign.spec.ts
+++ b/test/sign.spec.ts
@@ -7,7 +7,7 @@ import { Wallet as CryptoWallet } from "@ethersproject/wallet";
 import { TransactionRequest } from "@ethersproject/abstract-provider";
 
 import { expect, describe, it, beforeEach, beforeAll, afterAll } from "vitest";
-import { SingleEthereum, ISingleEthereum } from "../src";
+import { SingleEthereum, ISingleEthereum, EVM_IDENTIFIER } from "../src";
 import {
   disconnect,
   TEST_APPROVE_PARAMS,
@@ -17,6 +17,7 @@ import {
   TEST_ETHEREUM_CHAIN_PARSED,
   TEST_GOERLI_CHAIN_PARSED,
   TEST_NAMESPACES,
+  TEST_OPTIONAL_NAMESPACES,
   TEST_REQUIRED_NAMESPACES,
   TEST_UPDATED_NAMESPACES,
 } from "./shared";
@@ -47,6 +48,7 @@ describe("Sign Integration", () => {
     });
     const { uri, approval } = await dapp.connect({
       requiredNamespaces: TEST_REQUIRED_NAMESPACES,
+      optionalNamespaces: TEST_OPTIONAL_NAMESPACES,
     });
     uriString = uri || "";
     sessionApproval = approval;
@@ -109,6 +111,31 @@ describe("Sign Integration", () => {
       }),
       wallet.pair({ uri: uriString }),
     ]);
+  });
+  it("should approve session proposal with optional methods", async () => {
+    const newChainId = 2;
+    await Promise.all([
+      new Promise((resolve) => {
+        wallet.on("session_proposal", async (sessionProposal) => {
+          const { id, params, context } = sessionProposal;
+          expect(context).to.be.exist;
+          expect(context.verified.validation).to.eq("UNKNOWN");
+          session = await wallet.approveSession({
+            id,
+            ...TEST_APPROVE_PARAMS,
+            chainId: newChainId,
+          });
+          resolve(session);
+        });
+      }),
+      new Promise(async (resolve) => {
+        resolve(await sessionApproval());
+      }),
+      wallet.pair({ uri: uriString }),
+    ]);
+    expect(session.namespaces[EVM_IDENTIFIER].methods).to.deep.eq(
+      TEST_REQUIRED_NAMESPACES.eip155.methods.concat(TEST_OPTIONAL_NAMESPACES.eip155.methods),
+    );
   });
   it("should reject session proposal", async () => {
     const rejectionError = getSdkError("USER_REJECTED");


### PR DESCRIPTION
- Implemented a functionality where session proposal can be approved with a different `chainId` than the required. 
- When that happens, automatic `session_event` is emitted as well
- Added tests