### PR TITLE
fix: switch chain request chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@walletconnect/se-sdk",
   "description": "Single-Ethreum-SDK for WalletConnect Protocol",
   "private": false,
-  "version": "1.8.0",
+  "version": "1.8.1",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",

--- a/src/controllers/engine.ts
+++ b/src/controllers/engine.ts
@@ -250,6 +250,22 @@ export class Engine extends ISingleEthereumEngine {
   private onSessionRequest = async (event: SingleEthereumTypes.SessionRequest) => {
     event.params.chainId = parseChain(event.params.chainId);
 
+    if (
+      ["wallet_switchEthereumChain", "wallet_addEthereumChain"].includes(
+        event.params.request.method,
+      )
+    ) {
+      event.params.chainId = this.chainId.toString();
+    }
+
+    try {
+      await this.switchEthereumChain(event);
+    } catch (e) {
+      this.client.logger.warn(e);
+      const error = getSdkError("USER_REJECTED");
+      return this.rejectRequest({ id: event.id, topic: event.topic, error });
+    }
+
     if (parseInt(event.params.chainId) !== this.chainId || this.isSwitchChainRequest(event)) {
       this.client.logger.info(
         `Session request chainId ${event.params.chainId} does not match current chainId ${this.chainId}. Attempting to switch`,

--- a/src/controllers/engine.ts
+++ b/src/controllers/engine.ts
@@ -258,14 +258,6 @@ export class Engine extends ISingleEthereumEngine {
       event.params.chainId = this.chainId.toString();
     }
 
-    try {
-      await this.switchEthereumChain(event);
-    } catch (e) {
-      this.client.logger.warn(e);
-      const error = getSdkError("USER_REJECTED");
-      return this.rejectRequest({ id: event.id, topic: event.topic, error });
-    }
-
     if (parseInt(event.params.chainId) !== this.chainId || this.isSwitchChainRequest(event)) {
       this.client.logger.info(
         `Session request chainId ${event.params.chainId} does not match current chainId ${this.chainId}. Attempting to switch`,


### PR DESCRIPTION
- Assigns the wallet's active `chainId` on `wallet_switchEthereumChain` & `wallet_addEthereumChain` requests
- Updates patch version